### PR TITLE
RF msg fmt change & make work with SAMD RFM GW

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,69 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "/usr/include",
+                "/usr/local/include",
+                "${workspaceRoot}"
+            ],
+            "defines": [],
+            "intelliSenseMode": "clang-x64",
+            "browse": {
+                "path": [
+                    "/usr/include",
+                    "/usr/local/include",
+                    "${workspaceRoot}"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            },
+            "macFrameworkPath": [
+                "/System/Library/Frameworks",
+                "/Library/Frameworks"
+            ]
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "/usr/include",
+                "/usr/local/include",
+                "${workspaceRoot}"
+            ],
+            "defines": [],
+            "intelliSenseMode": "clang-x64",
+            "browse": {
+                "path": [
+                    "/usr/include",
+                    "/usr/local/include",
+                    "${workspaceRoot}"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            }
+        },
+        {
+            "name": "Win32",
+            "includePath": [
+                "C:/Program Files (x86)/Arduino",
+                "C:/Users/Paul/Dropbox/Electronics/Arduino/PJ Sketches",
+                "${workspaceRoot}"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE"
+            ],
+            "intelliSenseMode": "msvc-x64",
+            "browse": {
+                "path": [
+                    "C:/Program Files (x86)/Arduino",
+                    "C:/Users/Paul/Dropbox/Electronics/Arduino/PJ Sketches",
+                    "${workspaceRoot}"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            }
+        }
+    ],
+    "version": 3
+}

--- a/PJ-HA-Universal-Node.ino
+++ b/PJ-HA-Universal-Node.ino
@@ -255,7 +255,7 @@ void mqtt_subs(char* topic, byte* payload, unsigned int length)
 //-------------------------------------------------------------------------
 // GENERAL STARTUP VARIABLES & DEFAULTS 
 //-------------------------------------------------------------------------
-long  TXinterval = 120; // periodic transmission interval in seconds (This is Dev001 for this Node)
+long  TXinterval = 600; // periodic transmission interval in seconds (This is Dev001 for this Node)
 long  TIMinterval = 20; // timer interval in seconds (This is Dev007 for this Node)
 bool  toggleOnButton = true; // toggle output on button (This is Dev006 for this Node)
 bool	ackButton = false; // flag for message on button press

--- a/RF_parseCmd.cpp
+++ b/RF_parseCmd.cpp
@@ -464,7 +464,7 @@ switch (mes.devID) // devID indicates device (sensor) type
   case 400: // 400     - TestExtVar - purely for testing, does not represent any real external variable. (Real - R/W)
     if (mes.cmd == 0)  // WRITE
       {
-      extVar400 = mes.fltVal; 
+      extVar400 = mes.fltintVal; 
       if (setAck) send400 = true; // send message if required
       #ifdef DEBUGPJ2
         Serial.print("Setting extVar400 to ");
@@ -477,7 +477,7 @@ switch (mes.devID) // devID indicates device (sensor) type
   case 401: // 401     - MasterLEDBrightness (0-255) - if 0, tells DUE to turn off whole display. 1..255 means turn it on and set master brightness to X. (Real - R/W)
     if (mes.cmd == 0)  // WRITE
       {
-      extVar401 = mes.fltVal; 
+      extVar401 = mes.fltintVal; 
       if (setAck) send401 = true; // send message if required
       #ifdef DEBUGPJ2
         Serial.print("Setting extVar401 to ");

--- a/RF_receiveData.cpp
+++ b/RF_receiveData.cpp
@@ -1,128 +1,58 @@
 // ======== receiveData() : 
 // RF receive data from gateway over radio and
-// simply place a received message in "mes" structure, for actioning in parsecmd().
+// simply places a received message into the "mes" structure, for actioning in parsecmd().
 //
 
 #include "a.h" // My global defines and extern variables to help multi file comilation.
 
 bool receiveData() {
   bool validPacket = false;
-  bool MesSizeOK = false;
-  uint8_t tempRecvPacket[RF69_MAX_DATA_LEN];  // The RF packet layouts (in the code I picked up) were designed for AVRs only and so there is 
-                                              // an expectation that a receiving device uses 16 bit unsigned integers for 'int's
-                                              // rather than ARM (i.e. FEATHERM0RFM69 boards) which even when using the type
-                                              // uint16_t, still stores it in 32 bits with padding.  So we need to write a special receive
-                                              // routine here that is only used when we are on an ARM, that will pull in an 'AVR packet' 
-                                              // (as the RFM_GW is an AVR) and spread it out into the correct variables for the ARM to
-                                              // then work on.
 
   if (radio.receiveDone()) // check for received packets
     {
-    #ifdef DEBUGPJ2
+    #ifdef DEBUGx
       Serial.println();
-      Serial.println("<<<rf-rx<<< so Start receiveData()"); 
+      Serial.println("<<<rf-rx<<< so starting in receiveData()"); 
     #endif
+    
     CommsLEDStart = true; // set this flag so that the Comms LED will be turned on for a period and managed elsewhere.
   
-    #ifndef FEATHERM0RFM69  // i.e. we are on an AVR, so no special processing required.
-      if (radio.DATALEN == sizeof(mes))) // we got valid sized message from an AVR node.
+    if (radio.DATALEN == sizeof(mes)) // we got valid sized message.
       {
       mes = *(Message*)radio.DATA;  // copy radio packet
-      MesSizeOK = true;
-      Serial.println("Im an AVR and pack size OK"); 
-      }
-  
-    #else // i.e. we are on an ARM, so need to do special packet processing.
-      if (radio.DATALEN == 46) // we got valid sized message from an AVR node.
-      {
-      Serial.println("Im an ARM and pack size OK"); 
-      Serial.print("radio.DATA:");
-      for (int i=0; i<radio.DATALEN; i++)
-        {
-        Serial.print(radio.DATA[i]);
-        Serial.print(":");  
-        }
-      Serial.println();
-      // translate the message from ARM Node into std msg before proceeding.
-      for (int i=0; i<radio.DATALEN; i++)
-        {
-        tempRecvPacket[i] = radio.DATA[i];  // copy radio packet into temp byte array, ready for manipulation.
-        }
-      int16_t PJnodeID = tempRecvPacket[0] + (tempRecvPacket[1] * 256);
-      Serial.print("PJnodeID:"); Serial.println(PJnodeID);
-      int16_t PJdevID = tempRecvPacket[2] + (tempRecvPacket[3] * 256);
-      Serial.print("PJdevID:"); Serial.println(PJdevID);
-      int16_t PJcmd = tempRecvPacket[4] + (tempRecvPacket[5] * 256);
-      Serial.print("PJcmd:"); Serial.println(PJcmd);
-      int32_t PJintVal = tempRecvPacket[6] + (tempRecvPacket[7] * 256) + (tempRecvPacket[8] * 65536) + (tempRecvPacket[9] * 65536 * 256) ;
-      Serial.print("PJintVal:"); Serial.println(PJintVal);
-      float PJfltVal = 987.65;  // I haven't workjed out how to convert the relevant four bytes in tempRecvPacket back into fltVal yet
-                                // so for now I am just hard setting it at this obvious number.  Good thing is so far in my HA
-                                // system I am not WRITing any DEVices that are floats. fltVal is only used for READs.
-      Serial.print("PJfltVal:"); Serial.println(PJfltVal);
-      uint8_t PJpayLoad[32];
-      for (int i=14; i<radio.DATALEN; i++)
-        {
-        PJpayLoad[i-14] = radio.DATA[i];  // copy radio packet into temp byte array, ready for manipulation.
-        }
-      Serial.print("PJpayload:");
-      for (int i=0; i<32; i++)
-        {
-        Serial.print(PJpayLoad[i]);
-        Serial.print(":");  
-        }
-      Serial.println();
-
-      // Now put all the parameters into mes so the rest of teh sketch can use it as normal.
-      mes.nodeID = PJnodeID;
-      mes.devID = PJdevID;
-      mes.cmd = PJcmd;
-      mes.intVal = PJintVal;
-      mes.fltVal = PJfltVal;
-      for (int i=0; i<32; i++)
-      {
-      mes.payLoad[i] = PJpayLoad[i];
-      }
-      MesSizeOK = true;  
-      }
-    #endif  
-  
-  
-    if (!MesSizeOK) // wrong message size means trouble
-        {
-        #ifdef DEBUG
-          Serial.println("<<<< RF msg received but had invalid message size.");
-          Serial.print("radio.DATALEN:");
-          Serial.println(radio.DATALEN);
-  
-          Serial.print("expected mes size:");
-          Serial.println(sizeof(mes));
-        #endif
-        }
-    else
-      {
-      //mes = *(Message*)radio.DATA;
+      #ifdef DEBUGPJ2
+        Serial.println("<<<< Inbound RF packet was correct size."); 
+      #endif
+      
       validPacket = true; // YES, we have a packet !
       signalStrength = radio.RSSI;
-      #ifdef DEBUG
-        Serial.print("<-- Received message: ");
-        Serial.print("Node: ");
-        Serial.print(mes.nodeID);
-        Serial.print(" device: ");
-        Serial.print(mes.devID);
-        Serial.print(" cmd: ");
-        Serial.print(mes.cmd);
-        Serial.print(" intVal: ");
-        Serial.print(mes.intVal);
-        Serial.print(" fltVal: ");
-        Serial.print(mes.fltVal);
-        Serial.print(" payLoad: ");
-        Serial.print(mes.payLoad);
-        Serial.print(" , RSSI= ");
-        Serial.println(radio.RSSI);
+      #ifdef DEBUGPJ2
+      Serial.print("Inbound Message from Node:");Serial.print(radio.SENDERID);Serial.print(" with RSSI:");Serial.println(radio.RSSI);
+      Serial.println("=========RF msg data===================");
+      Serial.print("From devID:");Serial.println(mes.devID);
+      Serial.print("       cmd:");Serial.println(mes.cmd);
+      Serial.print("    intVal:");Serial.println(mes.intVal);
+      Serial.print(" fltintVal:");Serial.println(mes.fltintVal);
+      Serial.print("To  NodeID:");Serial.println(mes.nodeID);
+      Serial.print("   payLoad:");
+            for (int i=0; i<32; i++) Serial.print(mes.payLoad[i]);
+      Serial.println(":");
+      Serial.println("=======================================");
       #endif  
+
+      }  
+    else  // wrong message size means trouble
+      {
+      #ifdef DEBUGPJ2
+        Serial.println("ERROR: Inbound RF packet was incorrect size.");
+        Serial.print("radio.DATALEN:");
+        Serial.println(radio.DATALEN);
+        Serial.print("expected mes size:");
+        Serial.println(sizeof(mes));
+      #endif
       }
-    }
+ 
   if (radio.ACKRequested()) radio.sendACK(); // respond to any ACK request
+    }
   return validPacket; // return code indicates packet received
 } // end recieveData()

--- a/RF_sendMsg.cpp
+++ b/RF_sendMsg.cpp
@@ -4,14 +4,14 @@
 #include "a.h" // My global defines and extern variables to help multi file comilation.
 
 void sendMsg() { // prepares values to be transmitted
-  
+  float tempFloat;
   bool tx = false; // transmission flag
   int i;
   // prep clean RF mes structure
   mes.nodeID=NODEID;
   mes.devID = 999; // If I every see this in a message, I know something is wrong.
   mes.intVal = 0;
-  mes.fltVal = 0;
+  mes.fltintVal = 0;
   mes.cmd = 0; // '0' means no action needed in gateway
   // clean up payload as well, so it is always empty unless explicitly used.
   for ( i = 0; i < 32; i++){
@@ -88,14 +88,15 @@ void sendMsg() { // prepares values to be transmitted
       result = ADCL;
       result |= ADCH<<8;
       result = 1126400L / result; // Back-calculate in mV
-      mes.fltVal = float(result/1000.0); // Voltage in Volt (float)
+      tempFloat = float(result/1000.0);  // Voltage in Volt (float) 
+      mes.fltintVal = fltTofltint(tempFloat); 
     #else
-      mes.fltVal = 123.45;  // if it's not a Moteino board just send this fake number until I have time to setup 
+      mes.fltintVal = fltTofltint(123.45);  // if it's not a Moteino board just send this fake number until I have time to setup 
                             // code for other boards like my FeatherM0's.
     #endif
     txRadio();
     send4 = false;
-    mes.fltVal = 0;  // clear it after use.
+    mes.fltintVal = 0;  // clear it after use.
   }
   
   if (send5) { // Acknowledge on 'SET'
@@ -296,10 +297,10 @@ void sendMsg() { // prepares values to be transmitted
     #ifdef DS18
       temp = sensors.getTempCByIndex(0);
     #endif
-    mes.fltVal = temp; // Degrees Celcius (float)
+    mes.fltintVal = temp; // Degrees Celcius (float)
     send48 = false;
     txRadio();
-    mes.fltVal = 0;  // clear it after use.
+    mes.fltintVal = 0;  // clear it after use.
   }
 
   if (send49) { // Humidity
@@ -307,10 +308,10 @@ void sendMsg() { // prepares values to be transmitted
     #ifdef DHT
       hum = dht.readHumidity();
     #endif
-    mes.fltVal = hum; // Percentage (float)
+    mes.fltintVal = fltTofltint(hum); // Percentage (float)
     send49 = false;
     txRadio();
-    mes.fltVal = 0;  // clear it after use.
+    mes.fltintVal = 0;  // clear it after use.
   }
 
   if (send50) { // Temperature
@@ -321,10 +322,10 @@ void sendMsg() { // prepares values to be transmitted
     #ifdef DS18
       temp = sensors.getTempCByIndex(1);
     #endif
-    mes.fltVal = temp; // Degrees Celcius (float)
+    mes.fltintVal = fltTofltint(temp); // Degrees Celcius (float)
     send50 = false;
     txRadio();
-    mes.fltVal = 0;  // clear it after use.
+    mes.fltintVal = 0;  // clear it after use.
   }
 
   #ifdef MOTEINOWEATHER
@@ -343,30 +344,30 @@ void sendMsg() { // prepares values to be transmitted
       Serial.println("SENDMSG: sending dev51 - pressure");
     #endif
     mes.devID = 51;
-    mes.fltVal = WeatherShieldData[0]; // get pressure from MOTEINO Weather
+    mes.fltintVal = fltTofltint(WeatherShieldData[0]); // get pressure from MOTEINO Weather
     txRadio();
     send51 = false;
-    mes.fltVal = 0;  // clear it after use.
+    mes.fltintVal = 0;  // clear it after use.
   }
   if (send54) { // humidity
     #ifdef DEBUG
       Serial.println("SENDMSG: sending dev54 - humidity");
     #endif
     mes.devID = 54;
-    mes.fltVal = WeatherShieldData[1]; // get humidity from MOTEINO Weather
+    mes.fltintVal = fltTofltint(WeatherShieldData[1]); // get humidity from MOTEINO Weather
     txRadio();
     send54 = false;
-    mes.fltVal = 0;  // clear it after use.
+    mes.fltintVal = 0;  // clear it after use.
   }
   if (send55) { // temperature
     #ifdef DEBUG
       Serial.println("SENDMSG: sending dev55 - temperature");
     #endif
     mes.devID = 55;
-    mes.fltVal = WeatherShieldData[2]; // get temp from MOTEINO Weather
+    mes.fltintVal = fltTofltint(WeatherShieldData[2]); // get temp from MOTEINO Weather
     txRadio();
     send55 = false;
-    mes.fltVal = 0;  // clear it after use.
+    mes.fltintVal = 0;  // clear it after use.
   }
   #endif // MOTEINOWEATHER
 
@@ -380,20 +381,20 @@ void sendMsg() { // prepares values to be transmitted
       Serial.println("SENDMSG: sending dev52 - visible light");
     #endif
     mes.devID = 52;
-    mes.fltVal = TSL2651Data[0]; // get visible light level from TSL2651
+    mes.fltintVal = fltTofltint(TSL2651Data[0]); // get visible light level from TSL2651
     txRadio();
     send52 = false;
-    mes.fltVal = 0;  // clear it after use.
+    mes.fltintVal = 0;  // clear it after use.
   }
   if (send53) { // IR light
     #ifdef DEBUG
       Serial.println("SENDMSG: sending dev53 - IR light");
     #endif
     mes.devID = 53;
-    mes.fltVal = TSL2651Data[1]; // get IR light level from TSL2651
+    mes.fltintVal = fltTofltint(TSL2651Data[1]); // get IR light level from TSL2651
     txRadio();
     send53 = false;
-    mes.fltVal = 0;  // clear it after use.
+    mes.fltintVal = 0;  // clear it after use.
   }
   #endif // TSL2651
 
@@ -569,10 +570,10 @@ void sendMsg() { // prepares values to be transmitted
       Serial.println("SENDMSG: sending dev400-TestExtVar");
     #endif
     mes.devID = 400;
-    mes.fltVal = extVar400; // current value we have for it on this Node.
+    mes.fltintVal = fltTofltint(extVar400); // current value we have for it on this Node.
     txRadio();
     send400 = false;
-    mes.fltVal = 0;  // clear it after use.
+    mes.fltintVal = 0;  // clear it after use.
     }
   if (send401)  // 401     - MasterLEDBrightness (0-255) - if 0, tells DUE to turn off whole display. 1..255 means turn it on and set master brightness to X. (Real - R/W)
     {
@@ -580,10 +581,10 @@ void sendMsg() { // prepares values to be transmitted
       Serial.println("SENDMSG: sending dev401-MasterLEDBrightness");
     #endif
     mes.devID = 401;
-    mes.fltVal = extVar401; // current value we have for it on this Node.
+    mes.fltintVal = fltTofltint(extVar401); // current value we have for it on this Node.
     txRadio();
     send401 = false;
-    mes.fltVal = 0;  // clear it after use.
+    mes.fltintVal = 0;  // clear it after use.
     }
 #endif // EXTVAR40X
 

--- a/RF_txRadio.cpp
+++ b/RF_txRadio.cpp
@@ -37,8 +37,8 @@ void txRadio()
     Serial.print(mes.cmd);
     Serial.print(" intVal: ");
     Serial.print(mes.intVal);
-    Serial.print(" fltVal: ");
-    Serial.print(mes.fltVal);
+    Serial.print(" fltintVal: ");
+    Serial.print(mes.fltintVal);
     Serial.print(" payLoad:");
     Serial.print(mes.payLoad);
     Serial.print(" RSSI: ");
@@ -54,7 +54,7 @@ void txRadio()
 
   CommsLEDStart = true; // set this flag so that the Comms LED will be turned on for a period and managed elsewhere.
   #ifdef DEBUG
-    Serial.print("about to call sendWithRetry()");  
+    Serial.println("about to call sendWithRetry()");  
   #endif
  
   // #ifdef FEATHERM0RFM69
@@ -62,7 +62,7 @@ void txRadio()
   //   else Serial.println("FEATHER:No con...or no ACK");
   // #else
     if (radio.sendWithRetry(GATEWAYID, (const void*)(&mes), sizeof(mes)));
-    else Serial.println("AVR:No con...or no ACK");
+    else Serial.println("No con...or no ACK");
         // xxxx - when we hit the ELSE above, we should also flash an error/pwr LED a few times if available??? S.O.S pattern :)
   // #endif
 

--- a/a.h
+++ b/a.h
@@ -34,6 +34,8 @@
 
 #define SERIAL_BAUD 115200
 
+#define STRPAYLOADSIZE 32   // How many chars in the String Payload we send? (must match in GW and Node!!!!!)
+
 /* NODE TYPE - must select one ONLY!!!! */
 //#define ETHNODETYPE // can only be one of these types, never both.
 #define RFNODETYPE   // can only be one of these types, never both.
@@ -61,8 +63,8 @@
 
 /* NODE CORE CONFIGURATION PARAMETERS 
 ****************************************************/
-#define NODEID           97       // unique node ID within the closed network
-#define NODEIDSTRING node97       // as per above.  
+#define NODEID           51       // unique node ID within the closed network
+#define NODEIDSTRING node51       // as per above.  
 #define COMMS_LED_PIN  13          // RED - Comms traffic IP or RF for/from this node, activity indicator.
                                   // DO NOT USE D10-D13 on a Moteino (non mega) as they are in use for RFM69 SPI!
 #define COMMS_LED_ON_PERIOD 1000 // How long we keep it on for, in mSec.
@@ -83,8 +85,8 @@
 
 /* RF NODE TYPE CONFIGURATION PARAMETERS & LIBRARIES 
 ****************************************************/
-#define GATEWAYID 1	    // node ID of the RF Gateway is always 1 
-#define NETWORKID 100	// network ID of the RF network
+#define GATEWAYID 50	    // node ID of the RF Gateway is always 1 
+#define NETWORKID 111	// network ID of the RF network
 #define ENCRYPTKEY "xxxxxxxxxxxxxxxx" // 16-char encryption key; same as on RF Gateway!
     // Wireless settings Match frequency to the hardware version of the radio
     //#define FREQUENCY RF69_433MHZ
@@ -275,13 +277,13 @@
 // ==============================================
 // 'struct's that I had to place here not in main ino file, to assist compilation.
 //
-typedef struct {        // Radio packet structure max 66 bytes
-  int     nodeID;       // node identifier
-  int     devID;        // device identifier 0 is node; 31 is temperature, 32 is humidity
-  int     cmd;          // read or write
-  long    intVal;       // integer payload
-  float   fltVal;       // floating payload
-  char    payLoad[32];  // char array payload
+typedef struct {			// Radio packet structure max 66 bytes (only transmitted between RF GW <> Nodes, not over IP)
+  long  nodeID;			// FROM node. Using a long as its 32bits on AVR and ARM. 
+  long	devID;			// device identifier 0 is node; 31 is temperature, 32 is humidity
+  long	cmd;			  // read or write
+  long	intVal;			// integer payload
+  long	fltintVal;	// floating point payload, but multiplied by 100 and transported as a long.  Works on ARM and AVR the same.
+  char	payLoad[STRPAYLOADSIZE];	// char array, String payload
   } Message;
 
 
@@ -342,6 +344,7 @@ void setStaticOneColourLEDStrip(int stripnum);
 void setStaticPatternLEDStripMode(int stripnum, int stripmode);
 void setDynamicPatternLEDStripMode(int stripnum, int stripmode);
 void checkswitches();
+long fltTofltint(float floatIn);
 
 // =============================================
 // Global variables as 'externs' so individual files can compile if they use them.

--- a/fltTofltint.cpp
+++ b/fltTofltint.cpp
@@ -1,0 +1,16 @@
+// Subroutine to convert a Float to what I call a fltint, a Float Int :)
+// In order to safely send Floats between different platforms (AVR, SAMD etc) which treat Floats
+// differently, before I send them I simply multiply the by 100 and store the whole number in a signed long/32bit.
+// Then on the receiving side I just regenerate the Float from the fltint by dividing it by 100 and putting that val in a Float.
+// The process assumes I don't want more than 2 dec places as thats all that gets kept.
+
+#include "a.h" // My global defines and extern variables to help multi file comilation.
+
+//
+// ======== fltTofltint()
+//
+long fltTofltint(float floatIn){
+    
+    return(floatIn * 100);  // multiply by 100 and return it as a long.
+
+} // END - fltTofltint()


### PR DESCRIPTION
I have changed the overall Node Code to use 32bit or long for most of
the parameters it puts in the struct Message, to send over RF, so it no
longer matters if running on AVR op SAMD, RF frame exact same.  This was
tested and works with my still in test SAMD RFM GW on SenseBender board.