### PR TITLE
Node05 convert to feather m0 rfm69

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,16 +3,22 @@
         {
             "name": "Mac",
             "includePath": [
-                "/Users/ladmin/Library/Arduino15/packages/adafruit/hardware/samd/1.3.0/**",
-                "/usr/include",
+                "/Users/ladmin/Dropbox/Electronics/Arduino/PJ Sketches/libraries/RadioHead",
+                "/Users/ladmin/Dropbox/Electronics/Arduino/PJ Sketches/libraries/PubSubClient/src",
+                "/Users/ladmin/Dropbox/Electronics/Arduino/PJ Sketches/libraries/RTClib",
+                "/Users/ladmin/Dropbox/Electronics/Arduino/PJ Sketches/libraries/Adafruit_Fingerprint_Sensor_Library",
+                "/Users/ladmin/Dropbox/Electronics/Arduino/PJ Sketches/libraries/Adafruit_BMP085_Library",
+                "/Users/ladmin/Dropbox/Electronics/Arduino/PJ Sketches/libraries/Adafruit_Si7021_Library",
+                "/Users/ladmin/Dropbox/Electronics/Arduino/PJ Sketches/libraries/Adafruit_Unified_Sensor",
+                "/Users/ladmin/Dropbox/Electronics/Arduino/PJ Sketches/libraries/Adafruit_TSL2561",
                 "/usr/local/include",
-                "${workspaceRoot}"
+                "${workspaceRoot}",
+                "/Users/ladmin/Library/Arduino15/packages/adafruit/hardware/samd/1.5.11/**"
             ],
             "defines": [],
             "intelliSenseMode": "clang-x64",
             "browse": {
                 "path": [
-                    "/usr/include",
                     "/usr/local/include",
                     "${workspaceRoot}"
                 ],
@@ -24,7 +30,7 @@
                 "/Library/Frameworks"
             ],
             "forcedInclude": [
-                "/Users/ladmin/Library/Arduino15/packages/adafruit/hardware/samd/1.3.0/cores/arduino/Arduino.h"
+                "/Users/ladmin/Library/Arduino15/packages/adafruit/hardware/samd/1.5.11/cores/arduino/Arduino.h"
             ]
         },
         {

--- a/PJ-HA-Universal-Node.ino
+++ b/PJ-HA-Universal-Node.ino
@@ -260,7 +260,7 @@ void mqtt_subs(char* topic, byte* payload, unsigned int length)
 //-------------------------------------------------------------------------
 // GENERAL STARTUP VARIABLES & DEFAULTS 
 //-------------------------------------------------------------------------
-long  TXinterval = 120; // periodic transmission interval in seconds (This is Dev001 for this Node)
+long  TXinterval = 600; // periodic transmission interval in seconds (This is Dev001 for this Node)
 long  TIMinterval = 20; // timer interval in seconds (This is Dev007 for this Node)
 bool  toggleOnButton = true; // toggle output on button (This is Dev006 for this Node)
 bool	ackButton = false; // flag for message on button press

--- a/a.h
+++ b/a.h
@@ -67,15 +67,15 @@
 /* NODE CORE CONFIGURATION PARAMETERS 
 ****************************************************/
 
-#define CLIENT_ADDRESS    3       // RadioHead Mesh Addressing
+#define CLIENT_ADDRESS    5       // RadioHead Mesh Addressing
 #define debug_mode 1              // Set debug_mode to 1 for Serial Monitor (RH lib?)
-#define NODEID           03       // unique node ID within the closed network
-#define NODEIDSTRING node03       // as per above.  
-#define COMMS_LED_PIN  13          // RED - Comms traffic IP or RF for/from this node, activity indicator.
+#define NODEID           05       // unique node ID within the closed network
+#define NODEIDSTRING node05       // as per above.  
+#define COMMS_LED_PIN  6          // RED - Comms traffic IP or RF for/from this node, activity indicator.
                                    // DO NOT USE D10-D13 on a Moteino (non mega) as they are in use for RFM69 SPI!
                                    // The onboard RED LED on Feathers is D13.
 #define COMMS_LED_ON_PERIOD 1000 // How long we keep it on for, in mSec.
-#define STATUS_LED_PIN 13               // BLUE - Status LED, generally just blinking away so we know node has not crashed.
+#define STATUS_LED_PIN 20               // BLUE - Status LED, generally just blinking away so we know node has not crashed.
 #define STATUS_LED_CYCLE_PERIOD 5000   // (mSecs) Under normal circumstances how often should we flash the STATUS LED?
 #define STATUS_LED_ON_PERIOD 100       // (mSecs) How long we keep it on for per blink, in mSec.
 
@@ -130,19 +130,19 @@
 // NODE devices selection (actuators and sensors etc)
 //-------------------------------------------------------------------------
 // What kind of devices are enabled on this node?: (add PIN config in applicable segments below)
-#define DHTSENSOR   // note this was previously "DHT" but that is in fact used in the DHT library, so I shouldn't have it as a define myself!
-    #include "DHT.h" 
-    #define DHTPIN 10     // Pin on Arduino the DHxx's Data pin is connected to.
-    #define	DHTTYPE	DHT11 // type of sensor... DHT11 or DHT22
+//#define DHTSENSOR   // note this was previously "DHT" but that is in fact used in the DHT library, so I shouldn't have it as a define myself!
+//    #include "DHT.h" 
+//    #define DHTPIN 10     // Pin on Arduino the DHxx's Data pin is connected to.
+//    #define	DHTTYPE	DHT11 // type of sensor... DHT11 or DHT22
 //#define DS18
 //#define SLEEPY //node on batteries? can be used with either DS18 or PIR (not both due watchdog interference)
 
-// #define PIR1          // Have I attached a PIR
-//      #define PIR1PIN 4   // IF MEGA DO NOT HANG A LED OFF THIS PIN too. Maga won't detect a transition if you do!
+#define PIR1          // Have I attached a PIR
+      #define PIR1PIN 5   // IF MEGA DO NOT HANG A LED OFF THIS PIN too. Maga won't detect a transition if you do!
 
-//                           // signal pin from 1st PIR if attached, else ignored.
-//      #define PIRdelay delay(2000) // give the grid time to stabilize for the PIR, otherwise false triggers will occur after a send due to power dip (up to 2s?)
-//      #define PIRHOLDOFF 2       // blocking period between button and PIR messages (seconds) xxxx
+                           // signal pin from 1st PIR if attached, else ignored.
+      #define PIRdelay delay(2000) // give the grid time to stabilize for the PIR, otherwise false triggers will occur after a send due to power dip (up to 2s?)
+      #define PIRHOLDOFF 2       // blocking period between button and PIR messages (seconds) xxxx
 
 //#define PIR2          // Have I attached a 2nd PIR
 //   #define PIR2PIN 23         // signal pin from 2nd PIR if attached, else ignored.
@@ -157,26 +157,26 @@
 //#define SWITCH22
 //    #define SWITCH2PIN 999      // signal pin from 2nd SWITCH
 
-#define SOILMOISTURE1
-      #define SOILMOISTUREPIN1 A4 // Pin to read the Analog value from the soil moisture sensor 
-      #define SOILPOWERPIN1 6     // Pin to provide power (Vcc) to the Soil moisture sensor, so its not always on.
+// #define SOILMOISTURE1
+//       #define SOILMOISTUREPIN1 A4 // Pin to read the Analog value from the soil moisture sensor 
+//       #define SOILPOWERPIN1 6     // Pin to provide power (Vcc) to the Soil moisture sensor, so its not always on.
 
-#define SOILMOISTURE2
-      #define SOILMOISTUREPIN2 A5 // Pin to read the Analog value from the soil moisture sensor 
-      #define SOILPOWERPIN2 9     // Pin to provide power (Vcc) to the Soil moisture sensor, so its not always on.
+// #define SOILMOISTURE2
+//       #define SOILMOISTUREPIN2 A5 // Pin to read the Analog value from the soil moisture sensor 
+//       #define SOILPOWERPIN2 9     // Pin to provide power (Vcc) to the Soil moisture sensor, so its not always on.
 
-//#define ACTUATOR1     // Have I attached any actuators (i.e. digital out pins connected to devices)... 
-//      #define ACTUATOR1PIN A5    // contol pin for 1st ACTUATOR if attached, else ignored.
-//      #define ACTUATOR1REVERSE  // define this if you want the output pin of this Actuator to be LOW when ON, rather than HIGH when ON.
-// #define ACTUATOR2
-//     #define ACTUATOR2PIN 3   // contol pin for 2nd ACTUATOR if attached, else ignored.
-//     #define ACTUATOR2REVERSE  // define this if you want the output pin of this Actuator to be LOW when ON, rather than HIGH when ON.
-// #define ACTUATOR3
-//     #define ACTUATOR3PIN 6    // contol pin for 3rd ACTUATOR if attached, else ignored.
-//     #define ACTUATOR3REVERSE  // define this if you want the output pin of this Actuator to be LOW when ON, rather than HIGH when ON.
-// #define ACTUATOR4
-//     #define ACTUATOR4PIN 7    // contol pin for 4th ACTUATOR if attached, else ignored.
-//     #define ACTUATOR4REVERSE  // define this if you want the output pin of this Actuator to be LOW when ON, rather than HIGH when ON.
+#define ACTUATOR1     // Have I attached any actuators (i.e. digital out pins connected to devices)... 
+     #define ACTUATOR1PIN 21    // contol pin for 1st ACTUATOR if attached, else ignored.
+     #define ACTUATOR1REVERSE  // define this if you want the output pin of this Actuator to be LOW when ON, rather than HIGH when ON.
+#define ACTUATOR2
+    #define ACTUATOR2PIN 14   // contol pin for 2nd ACTUATOR if attached, else ignored.
+    #define ACTUATOR2REVERSE  // define this if you want the output pin of this Actuator to be LOW when ON, rather than HIGH when ON.
+#define ACTUATOR3
+    #define ACTUATOR3PIN 15   // contol pin for 3rd ACTUATOR if attached, else ignored.
+    #define ACTUATOR3REVERSE  // define this if you want the output pin of this Actuator to be LOW when ON, rather than HIGH when ON.
+#define ACTUATOR4
+    #define ACTUATOR4PIN 16   // contol pin for 4th ACTUATOR if attached, else ignored.
+    #define ACTUATOR4REVERSE  // define this if you want the output pin of this Actuator to be LOW when ON, rather than HIGH when ON.
 
 //#define SERIALSLAVE   // Has this node got a subordinate sub node under it via hw Serial1 port?
 

--- a/a.h
+++ b/a.h
@@ -18,8 +18,8 @@
 
 #include "pitches.h"  // my file with musical note definitions for BEEPER device.
 #include <Adafruit_Fingerprint.h> // Designed to work with  http://www.adafruit.com/products/751 finger sensor
-#include <SFE_BMP180.h>    //get it here: https://github.com/LowPowerLab/SFE_BMP180
-#include <SI7021.h>        //get it here: https://github.com/LowPowerLab/SI7021
+#include <Adafruit_BMP085.h>    //get it from Library Manager - Previously I used: https://github.com/LowPowerLab/SFE_BMP180
+#include <Adafruit_Si7021.h>        //get it from Library Manager - Previously I used: https://github.com/LowPowerLab/SI7021
 #include <Adafruit_Sensor.h>      // required for TSL2561 sensor stuff
 #include <Adafruit_TSL2561_U.h>
 //#include "Nextion.h"              //get it here: https://github.com/itead/ITEADLIB_Arduino_Nextion 
@@ -75,7 +75,7 @@
                                    // DO NOT USE D10-D13 on a Moteino (non mega) as they are in use for RFM69 SPI!
                                    // The onboard RED LED on Feathers is D13.
 #define COMMS_LED_ON_PERIOD 1000 // How long we keep it on for, in mSec.
-#define STATUS_LED_PIN 20               // BLUE - Status LED, generally just blinking away so we know node has not crashed.
+#define STATUS_LED_PIN 18               // BLUE - Status LED, generally just blinking away so we know node has not crashed.
 #define STATUS_LED_CYCLE_PERIOD 5000   // (mSecs) Under normal circumstances how often should we flash the STATUS LED?
 #define STATUS_LED_ON_PERIOD 100       // (mSecs) How long we keep it on for per blink, in mSec.
 
@@ -166,7 +166,7 @@
 //       #define SOILPOWERPIN2 9     // Pin to provide power (Vcc) to the Soil moisture sensor, so its not always on.
 
 #define ACTUATOR1     // Have I attached any actuators (i.e. digital out pins connected to devices)... 
-     #define ACTUATOR1PIN 21    // contol pin for 1st ACTUATOR if attached, else ignored.
+     #define ACTUATOR1PIN 17    // contol pin for 1st ACTUATOR if attached, else ignored.
      #define ACTUATOR1REVERSE  // define this if you want the output pin of this Actuator to be LOW when ON, rather than HIGH when ON.
 #define ACTUATOR2
     #define ACTUATOR2PIN 14   // contol pin for 2nd ACTUATOR if attached, else ignored.


### PR DESCRIPTION
As this was the first Node to get an ESP01 esp-link added to it, I had to make additional changes to the base Node code, hence I am pulling those changes back into the master here. Here are the relevant Comments from within my code.

Define which Serial the debugs/console output go to.
// ----------------------------------------------------
// I added this in April 2020 when working on Node05 (Rear Sprinkler) as I wanted to redirect 
// this output to Serial1 when I use a Feather. This is because  
// Feathers only expose Serial1 on pins that you can connect to, Serial is only on the USB port.
// The reason I want to be able to redirect to a Serial port that is brought out on physical pins
// is so that when I attach one of my new esp-link ESP8266 modules to the "console" of a Node, it needs
// access to physical serial port pins to see the debug/console output. See also my Evernote "esp-link for 8266".
